### PR TITLE
Add guidance on procuring climate risk assessments

### DIFF
--- a/ecdg_report/_quarto.yml
+++ b/ecdg_report/_quarto.yml
@@ -160,6 +160,7 @@ format:
 bibliography:
   - datasets/references.bib
   - adaptation/adaptation.bib
+  - guidance/guidance.bib
   - sectors/references.bib
   - sectors/infrastructure/references_dam_safety.bib
   - sectors/planning/references.bib

--- a/ecdg_report/_quarto.yml
+++ b/ecdg_report/_quarto.yml
@@ -89,6 +89,7 @@ website:
           - guidance/traditional_knowledge.qmd
           - guidance/Climate_Information_Ressources.qmd
           - guidance/IPCC_information.qmd
+          - guidance/Guidance_Harrington.qmd
           - guidance/Example_Applications.ipynb
           - section: "Analysis Support Tools"
             href: guidance/tools/Analysis_Support_Tools.ipynb

--- a/ecdg_report/guidance/Guidance_Harrington.qmd
+++ b/ecdg_report/guidance/Guidance_Harrington.qmd
@@ -8,7 +8,7 @@ Physical climate risk assessments are often commissioned from external providers
 
 This page provides questions that electricity-sector organisations can use when procuring or reviewing a physical climate risk assessment. It is intended to support informed discussion with climate-risk information providers. It is not a substitute for technical review by qualified climate scientists.
 
-This guidance is adapted from Harrington et al. (2025), who propose eight questions for organisations procuring physical climate risk assessments.
+This guidance is adapted from @Harrington2025, who propose eight questions for organisations procuring physical climate risk assessments.
 
 ## How to use this guidance
 
@@ -168,7 +168,8 @@ The quality and detail of climate information should match the decision being su
 
 For highly local or asset-specific decisions, consider using climate information alongside stress testing and physically plausible storylines. These approaches can help explore consequences under credible conditions without implying a level of local precision that the available climate evidence cannot support. For more on this, we suggest to consult the Adaptation section of this guide.
 
-## Reference
+## References
 
-Harrington, L. J., Gibson, P. B., Fauchereau, N., Lewis, H., Frame, D., & Rosier, S. M. (2025). On the procurement of physical risk assessments for climate-related disclosures: guidance from a climate science perspective. *Journal of the Royal Society of New Zealand*, 55(6), 2260–2269. https://doi.org/10.1080/03036758.2025.2486044
+::: {#refs}
+:::
 

--- a/ecdg_report/guidance/Guidance_Harrington.qmd
+++ b/ecdg_report/guidance/Guidance_Harrington.qmd
@@ -71,7 +71,7 @@ An ensemble mean alone can conceal important differences between plausible outco
 
 A useful response should include:
 
-* the number and name of models used;
+* the number and names of models used;
 * the emissions scenarios considered (or levels of warming);
 * the range of projected changes across models;
 * areas of robust agreement; and

--- a/ecdg_report/guidance/Guidance_Harrington.qmd
+++ b/ecdg_report/guidance/Guidance_Harrington.qmd
@@ -1,0 +1,174 @@
+---
+title: "Procuring Physical Climate Risk Assessments"
+---
+
+## Purpose
+
+Physical climate risk assessments are often commissioned from external providers. A useful assessment is not defined only by the amount of data it provides or the apparent detail of its maps. It must also use climate information that is appropriate for the hazard, the decision, and the spatial scale being assessed.
+
+This page provides questions that electricity-sector organisations can use when procuring or reviewing a physical climate risk assessment. It is intended to support informed discussion with climate-risk information providers. It is not a substitute for technical review by qualified climate scientists.
+
+This guidance is adapted from Harrington et al. (2025), who propose eight questions for organisations procuring physical climate risk assessments.
+
+## How to use this guidance
+
+One can use these questions when:
+
+* defining the scope of an assessment;
+* reviewing proposals from prospective providers;
+* discussing methods and assumptions during a project;
+* interpreting results and their limitations; and
+* deciding whether the available information is adequate for the intended use.
+
+The level of evidence required should reflect the consequence of the decision, the lifetime of the asset or investment, the reversibility of the decision, and the scale at which the information will be used.
+
+## Questions to ask a climate-risk information provider
+
+### 1. What are the spatial scales of the physical processes governing each climate hazard being assessed?
+
+Ask the provider to explain the physical processes that drive the hazard of concern and why the selected modelling approach can represent their expected response to climate change.
+
+For example, a hazard may be governed primarily by large-scale circulation, regional topography, convective storms, snow processes, or local land-surface conditions. The key issue is whether the climate information can represent the relevant mechanisms adequately for the purpose of the assessment.
+
+The provider should explain:
+
+* the principal processes governing the hazard;
+* which aspects of those processes are represented by the modelling approach; and
+* any important processes or local influences that are not reliably represented.
+
+### 2. What is the horizontal resolution of the climate-model output used to estimate future changes in physical risk?
+
+Ask for a clear description of the climate-data chain used in the assessment.
+
+The provider should identify:
+
+* the original climate-model (global and/or regional) dataset;
+* the horizontal resolution of the underlying simulations; and
+* whether the final data were statistically downscaled or bias adjusted.
+
+This question establishes what data are actually underpinning the assessment. It should distinguish the resolution of the original model output from the grid spacing of any final processed product.
+
+### 3. How does the scale of the underlying climate-model simulations compare with the scale of the final climate-risk information being provided?
+
+Ask the provider to explain whether the underlying climate information is suitable for the scale at which conclusions are being presented and decisions are being made.
+
+For example, information appropriate for national or regional screening may not support quantitative conclusions for an individual facility, transmission corridor, dam, or substation.
+
+The provider should explain:
+
+* the intended scale of use of the final risk information;
+* the main limitations created by any difference between that scale and the underlying simulations; and
+* how those limitations affect the confidence that can be placed in the results.
+
+Where highly local information is requested, the provider should clearly distinguish between useful local decision support and claims of precise local prediction.
+
+
+### 4. How many different climate models have been considered, and what spread do they show in projected physical climate risk?
+
+Ask whether the assessment uses multiple climate models and how the projected changes vary between them.
+
+An ensemble mean alone can conceal important differences between plausible outcomes. Where models disagree about the direction or magnitude of change, the assessment should show that spread rather than present only an average value.
+
+A useful response should include:
+
+* the number and name of models used;
+* the emissions scenarios considered (or levels of warming);
+* the range of projected changes across models;
+* areas of robust agreement; and
+* areas where model disagreement is substantial.
+
+### 5. For information on extreme weather events, what is the total number of model years or independent model realisations supporting the estimates?
+
+Rare events require large samples to estimate changes in frequency or intensity credibly. Ask whether the number of available model years is adequate for the rarity of the event being assessed.
+
+A useful response should explain:
+
+* the number of independent model realisations or total model years;
+* the rarity of the event or threshold being considered;
+* any statistical methods used to estimate rare-event probabilities or return periods; and
+* the uncertainty associated with those estimates.
+
+Be cautious when highly specific estimates of rare-event frequency are presented without a clear account of sample size and uncertainty.
+
+### 6. What bias-adjustment methods have been used, and for which variables?
+
+Ask the provider to describe the bias-adjustment method, the variables adjusted, and why that approach is appropriate for the intended application.
+
+Bias adjustment can be useful, particularly when climate data are required as inputs to impact models. However, it does not correct for missing physical processes or make coarse-resolution climate-model output suitable for every local application.
+
+A useful response should identify:
+
+* the bias-adjustment method used;
+* the variables adjusted;
+* whether the method preserves relationships among multiple variables;
+* limitations for compound hazards and extremes; and
+* why the method is appropriate for the intended use.
+
+### 7. What is the density and quality of weather-station observations underpinning the observational product used for bias adjustment?
+
+Ask what observational data were used as the reference for bias adjustment and whether they are sufficiently representative of the location and hazard of interest.
+
+The credibility of bias-adjusted climate information depends partly on the quality, length, density, and geographical coverage of the underlying observations. A high-resolution global observational product may still rely on sparse local station coverage.
+
+A useful response should identify:
+
+* the observational product or station network used;
+* the density and distribution of contributing weather stations;
+* the period of record;
+* known limitations in station coverage or data quality; and
+* why the observational basis is appropriate for the intended assessment.
+
+### 8. Do the methods and models have a transparent explanation that can be traced to peer-reviewed literature?
+
+A provider should be able to explain the scientific basis of the assessment clearly enough for users to understand its appropriate uses and limitations.
+
+Commercial confidentiality should not prevent disclosure of the principal methods, assumptions, data sources, and limitations.
+
+A useful response should provide:
+
+* the climate models and scenarios used;
+* downscaling and bias-adjustment methods;
+* observational datasets;
+* treatment of uncertainty;
+* known limitations;
+* technical documentation; and
+* relevant peer-reviewed literature.
+
+## Evidence to request
+
+A procurement process should normally request:
+
+* a list of climate models, scenarios, and ensemble members;
+* model resolution and downscaling approach;
+* information on historical evaluation and validation;
+* the observational datasets used;
+* treatment of model, scenario, and internal-variability uncertainty;
+* uncertainty ranges, not only central estimates;
+* known limitations at the relevant decision scale; and
+* references to scientific literature and technical guidance.
+
+## Warning signs
+
+Be cautious when an assessment:
+
+* provides highly precise asset-scale numbers without explaining uncertainty;
+* is based on a single climate model;
+* presents only an ensemble mean and not the underlying range of model outcomes;
+* does not identify the underlying climate models or scenarios;
+* treats bias adjustment as a complete solution to model-resolution limitations;
+* does not describe the observational data used;
+* provides return periods for rare extremes without discussing sample size;
+* cannot provide transparent documentation of methods and limitations; or
+* does not use a methodology that can be traced back to peer-reviewed scientific literature.
+
+
+## Implications for electricity-sector decisions
+
+The quality and detail of climate information should match the decision being supported. Broad portfolio screening may be adequately supported by relatively coarse climate information for some hazards. Decisions involving safety-critical infrastructure, long-lived assets, engineering design, resource adequacy, or operational reliability may require more tailored evidence, explicit uncertainty treatment, and expert review.
+
+For highly local or asset-specific decisions, consider using climate information alongside stress testing and physically plausible storylines. These approaches can help explore consequences under credible conditions without implying a level of local precision that the available climate evidence cannot support. For more on this, we suggest to consult the Adaptation section of this guide.
+
+## Reference
+
+Harrington, L. J., Gibson, P. B., Fauchereau, N., Lewis, H., Frame, D., & Rosier, S. M. (2025). On the procurement of physical risk assessments for climate-related disclosures: guidance from a climate science perspective. *Journal of the Royal Society of New Zealand*, 55(6), 2260–2269. https://doi.org/10.1080/03036758.2025.2486044
+

--- a/ecdg_report/guidance/guidance.bib
+++ b/ecdg_report/guidance/guidance.bib
@@ -1,0 +1,15 @@
+@article{Harrington2025,
+author = {Harrington, Luke J. and Gibson, Peter B. and Fauchereau, Nicolas and Lewis, Hamish and Frame, Dave and Rosier, Suzanne M.},
+title = {On the procurement of physical risk assessments for climate-related disclosures: guidance from a climate science perspective},
+journal = {Journal of the Royal Society of New Zealand},
+volume = {55},
+number = {6},
+pages = {2260-2269},
+keywords = {Climate-related disclosures, climate change, climate model evaluation, climate risks, uncertainty},
+doi = {https://doi.org/10.1080/03036758.2025.2486044},
+url = {https://rsnz.onlinelibrary.wiley.com/doi/abs/10.1080/03036758.2025.2486044},
+eprint = {https://rsnz.onlinelibrary.wiley.com/doi/pdf/10.1080/03036758.2025.2486044},
+abstract = {ABSTRACT Following legislation introduced in 2021, many listed companies in New Zealand (Climate Reporting Entities, hereafter CREs) are required to produce annual climate-related disclosures as part of their financial risk reporting. Within these disclosures sits an expectation that ‘climate-related risks and opportunities’, including both existing and future physical climate risks to their portfolios, can be quantified in some way. However, because many CREs lack the requisite scientific expertise within their own organisations to produce such assessments, these exercises are often outsourced to third-party providers of climate risk information (hereafter, TPPCRIs). Here, we propose eight questions that CREs could ask these TPPCRIs, so to ensure the end-product is not just consistent with the expectations of the New Zealand Climate Standards but also with our best-available understanding of the science of climate change.},
+year = {2025}
+}
+


### PR DESCRIPTION
Based on Harrington et al. (2025)

Harrington, L. J., Gibson, P. B., Fauchereau, N., Lewis, H., Frame, D., & Rosier, S. M. (2025). On the procurement of physical risk assessments for climate-related disclosures: guidance from a climate science perspective. *Journal of the Royal Society of New Zealand*, 55(6), 2260–2269. https://doi.org/10.1080/03036758.2025.2486044

@vindelico I didn't feel confident to touch the bib tex file, so I couldn't cite the reference properly. Do you think you could make this modification yourself?